### PR TITLE
Add HTML version of business plan

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Business Plan - SmartSUD</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+</head>
+<body>
+    <header>
+        <h1>Business Plan – SmartSUD Estruturação Estratégica</h1>
+    </header>
+    <main id="content">
+        <!-- Markdown content will be loaded here -->
+    </main>
+    <footer>
+        <p>Versão HTML gerada a partir do documento original.</p>
+    </footer>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,11 @@
+// Carrega o arquivo Markdown e converte para HTML
+fetch('SmartSUD - Rev.2025.06.01.md')
+  .then(response => response.text())
+  .then(text => {
+    const html = marked.parse(text);
+    document.getElementById('content').innerHTML = html;
+  })
+  .catch(error => {
+    document.getElementById('content').innerHTML = '<p>Erro ao carregar o conteúdo.</p>';
+    console.error(error);
+  });

--- a/style.css
+++ b/style.css
@@ -1,0 +1,25 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    line-height: 1.6;
+    background-color: #f5f5f5;
+}
+header {
+    background-color: #004080;
+    color: #fff;
+    padding: 1rem;
+    text-align: center;
+}
+main {
+    max-width: 800px;
+    margin: auto;
+    padding: 1rem;
+    background-color: #fff;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}
+footer {
+    text-align: center;
+    padding: 1rem;
+    color: #666;
+}


### PR DESCRIPTION
## Summary
- create `index.html` to display the business plan in HTML
- add `style.css` for simple styling
- add `script.js` to load the Markdown content dynamically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405da0e518832280f316a1e03852ab