### PR TITLE
Handle custom heading IDs

### DIFF
--- a/docs/00-intro.md
+++ b/docs/00-intro.md
@@ -1,10 +1,10 @@
 ## **![][image1]**
 
-## **Business Plan – SmartSUD Estruturação Estratégica** 
+## **Business Plan – SmartSUD Estruturação Estratégica** {#business-plan-–-smartsud-estruturação-estratégica} 
 
 ---
 
-[**Business Plan – SmartSUD Estruturação Estratégica	2**](#heading=h.xfaxhmeaip3o)
+[**Business Plan – SmartSUD Estruturação Estratégica	2**](#business-plan-–-smartsud-estruturação-estratégica)
 
 [1\. Visão Geral	3](#1.-visão-geral)
 

--- a/script.js
+++ b/script.js
@@ -17,7 +17,17 @@ const modules = [
 Promise.all(modules.map(file => fetch(file).then(res => res.text())))
   .then(texts => {
     const html = texts.map(t => marked.parse(t)).join('\n');
-    document.getElementById('content').innerHTML = html;
+    const content = document.getElementById('content');
+    content.innerHTML = html;
+
+    // Apply custom IDs defined in headings using the {#id} syntax
+    content.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach(heading => {
+      const match = heading.innerHTML.match(/\s*\{#([^}]+)\}\s*$/);
+      if (match) {
+        heading.innerHTML = heading.innerHTML.replace(/\s*\{#[^}]+\}\s*$/, '').trim();
+        heading.id = match[1];
+      }
+    });
   })
   .catch(error => {
     document.getElementById('content').innerHTML = '<p>Erro ao carregar o conteúdo.</p>';


### PR DESCRIPTION
## Summary
- parse `{#id}` from generated heading HTML
- assign stripped IDs to headings
- set a matching ID and anchor in the intro document

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840fe8d79888322b89cc56d8101006e