### PR TITLE
Add <br> conversions for tables

### DIFF
--- a/script.js
+++ b/script.js
@@ -19,6 +19,10 @@ Promise.all(modules.map(file => fetch(file).then(res => res.text())))
     const html = texts.map(t => marked.parse(t)).join('\n');
     const content = document.getElementById('content');
     content.innerHTML = html;
+    // Preserve line breaks inside table cells
+    content.querySelectorAll('td').forEach(td => {
+      td.innerHTML = td.innerHTML.replace(/\n/g, '<br>');
+    });
 
     // Apply custom IDs defined in headings using the {#id} syntax
     content.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach(heading => {

--- a/style.css
+++ b/style.css
@@ -140,3 +140,24 @@ footer {
         font-size: 0.9rem;
     }
 }
+
+/* Estilos para tabelas convertidas do Markdown */
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1rem 0;
+}
+
+table th,
+table td {
+    border: 1px solid #ccc;
+    padding: 0.75rem;
+    text-align: left;
+    vertical-align: top;
+    white-space: pre-line;
+}
+
+table th {
+    background-color: #f0f0f0;
+    text-align: center;
+}


### PR DESCRIPTION
## Summary
- ensure newlines in table cells are preserved by converting them to `<br>` after rendering Markdown

## Testing
- `tidy -qe index.html`


------
https://chatgpt.com/codex/tasks/task_e_684499b713788322b87e297cbd26b638